### PR TITLE
Add long description into shed sylph tax DM

### DIFF
--- a/data_managers/data_manager_sylph_tax_database/.shed.yml
+++ b/data_managers/data_manager_sylph_tax_database/.shed.yml
@@ -2,6 +2,8 @@ name: data_manager_sylph_tax_database
 owner: bgruening
 description: "Download sylph-tax taxonomy metadata files"
 homepage_url: "https://github.com/bluenote-1577/sylph-tax"
+long_description: |
+    Downloads sylph-tax taxonomy metadata files for pre-built databases
 remote_repository_url: "https://github.com/bgruening/galaxytools/tree/master/data_managers/data_manager_sylph_tax_database"
 type: unrestricted
 categories:


### PR DESCRIPTION
Error seem to be here : https://github.com/bgruening/galaxytools/actions/runs/14887157930/job/41809831165?pr=1518#step:5:475, with : Missing shed metadata field long_description.
I hope this solves the problem. If not, maybe you can add me so that I can make the changes directly on the main repo and you don't have to merge all my commits each time there are modifications.